### PR TITLE
Core/file system

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ An open-sourced markdown editor && noteTaking desktop application based on .md
 
 ## 💖feature
 * supports ✔WYSIWYG (rich text), ❌instant rendering, ✔ tranditional split view editing
-* supports git extension
-* provides great noteTaking-like user experience
+* ❌supports git extension
+* ❌provides great noteTaking-like user experience
 
 ## 👁‍🗨Screen shots (2021.8.5)
 ![screenshot](./doc/assets/2021.8.5.png)

--- a/src/base/common/event.ts
+++ b/src/base/common/event.ts
@@ -42,3 +42,5 @@ export class EventEmitter implements IEventEmitter {
     }
 
 }
+
+export const EVENT_EMITTER = new EventEmitter();

--- a/src/base/common/string.ts
+++ b/src/base/common/string.ts
@@ -48,11 +48,11 @@ export function nameIncludeCheckWithRule(name: string, rules: string[]): boolean
                 } else {
                     postfix += char;
                 }
-            } else if (asteriskFound) {
-                throw 'mutiple asterisk has found';
             } else {
                 asteriskFound = true;
-                continue;
+                if (i + 1 !== rule.length && i !== 0) {
+                    throw 'wrong rules is applied to be included';
+                }
             }
         }
 

--- a/src/code/common/notebook.ts
+++ b/src/code/common/notebook.ts
@@ -1,4 +1,4 @@
-import { FileTree, FileNode } from "src/base/node/fileTree";
+import { FileTree } from "src/base/node/fileTree";
 
 export interface INoteBook {
     readonly noteBookName: string;
@@ -6,18 +6,28 @@ export interface INoteBook {
     readonly firstCreatedDate?: Date;
     readonly fileTree: FileTree;
 
+    /**
+     * @description synchronously building the whole notebook folder tree and
+     * display it.
+     * 
+     * @param parent fileTree appends to this parent HTMLElement
+     */
+    create(parent: HTMLElement): void;
+    
+    /**
+     * @description destroy the notebook instance.
+     */
     destory(): void;
 }
 
 /**
- * @description NoteBook is considered as 
+ * @description TODO: complete comments
  */
 export class NoteBook {
 
     public readonly noteBookName: string;
     public readonly noteBookDir: string;
 
-    public readonly firstCreatedDate?: Date;
     public readonly fileTree: FileTree;
 
     /**
@@ -29,8 +39,10 @@ export class NoteBook {
         this.noteBookDir = path;
         
         this.fileTree = new FileTree(path);
-        this.fileTree.createFolderTree();
-        this.fileTree.createFolderTreeList();
+    }
+
+    public create(parent: HTMLElement): void {
+        this.fileTree.create(parent);
     }
 
     public destory(): void {

--- a/src/code/common/notebookManger.ts
+++ b/src/code/common/notebookManger.ts
@@ -32,8 +32,12 @@ export class NoteBookManager implements INoteBookManager {
 
     private _noteBookDir!: string;
 
+    // not used
+    private _mdNoteFolderFound: boolean;
+
     constructor() {
         this.noteBookMap = new Map<string, NoteBook>();
+        this._mdNoteFolderFound = false;
     }
 
     public async init(path: string): Promise<void> {
@@ -48,6 +52,7 @@ export class NoteBookManager implements INoteBookManager {
                 } else {
                     this._createNoteBookConfig();
                 }
+                this._mdNoteFolderFound = true;
                 resolve();
             }).catch((err) => {
                 // do log here.

--- a/src/code/workbench/browser/actionBar/actionBar.ts
+++ b/src/code/workbench/browser/actionBar/actionBar.ts
@@ -1,5 +1,5 @@
 import { Button, IButton } from 'src/base/browser/basic/button';
-import { IEventEmitter } from 'src/base/common/event';
+import { EVENT_EMITTER } from 'src/base/common/event';
 import { ActionViewType } from 'src/code/workbench/browser/actionView/actionView';
 import { Component, ComponentType } from 'src/code/workbench/browser/component';
 import { IRegisterService } from 'src/code/workbench/service/registerService';
@@ -12,17 +12,12 @@ import { IRegisterService } from 'src/code/workbench/service/registerService';
 export class ActionBarComponent extends Component {
 
     private _buttonGroups: IButton[] = [];
-    private _eventEmitter: IEventEmitter;
     
     // if value is -1, it means actionView is not shown.
     private currFocusActionBtnIndex: number;
 
-    constructor(registerService: IRegisterService,
-                _eventEmitter: IEventEmitter        
-    ) {
+    constructor(registerService: IRegisterService) {
         super(ComponentType.ActionBar, registerService);
-        
-        this._eventEmitter = _eventEmitter;
         
         this.currFocusActionBtnIndex = -1;
     }
@@ -83,7 +78,7 @@ export class ActionBarComponent extends Component {
         const actionName = clickedBtn.id.slice(0, -"-button".length) as ActionViewType;
         
         // switch to the action view
-        this._eventEmitter.emit('EOnActionViewChange', actionName);
+        EVENT_EMITTER.emit('EOnActionViewChange', actionName);
 
         // focus the action button and reverse the state of action view
         const clickedBtnIndex = parseInt(clickedBtn.getAttribute('btnNum') as string);
@@ -93,12 +88,12 @@ export class ActionBarComponent extends Component {
         if (this.currFocusActionBtnIndex == -1) {
             // none of action button is focused, open the action view
             this.currFocusActionBtnIndex = clickedBtnIndex;
-            this._eventEmitter.emit('EOnActionViewOpen');
+            EVENT_EMITTER.emit('EOnActionViewOpen');
             clickedBtn.classList.add('action-button-focus');
         } else if (this.currFocusActionBtnIndex == clickedBtnIndex) {
             // if the current focused button is clicked again, close action view.
             this.currFocusActionBtnIndex = -1;
-            this._eventEmitter.emit('EOnActionViewClose');
+            EVENT_EMITTER.emit('EOnActionViewClose');
             currBtn.classList.remove('action-button-focus');
         } else if (this.currFocusActionBtnIndex >= 0) {
             // other action button is clicked, only change the style

--- a/src/code/workbench/browser/actionView/actionView.ts
+++ b/src/code/workbench/browser/actionView/actionView.ts
@@ -2,7 +2,7 @@ import { getSvgPathByName } from 'src/base/common/string';
 import { Component, ComponentType } from 'src/code/workbench/browser/component';
 import { IRegisterService } from 'src/code/workbench/service/registerService';
 import { ExplorerViewComponent } from "src/code/workbench/browser/actionView/explorer/explorer";
-import { IEventEmitter } from 'src/base/common/event';
+import { EVENT_EMITTER } from 'src/base/common/event';
 import { INoteBookManager } from 'src/code/common/notebookManger';
 
 export type ActionViewType = 'none' | 'explorer' | 'outline' | 'search' | 'git';
@@ -29,17 +29,14 @@ export class ActionViewComponent extends Component {
 
     private explorerViewComponent!: ExplorerViewComponent;
     
-    private _eventEmitter: IEventEmitter;
     private _noteBookManager: INoteBookManager;
     // Others...
 
     constructor(registerService: IRegisterService,
-                _eventEmitter: IEventEmitter,
                 _noteBookManager: INoteBookManager
     ) {
         super(ComponentType.ActionView, registerService);
         
-        this._eventEmitter = _eventEmitter;
         this._noteBookManager = _noteBookManager;
         this.whichActionView = 'none';
     }
@@ -79,9 +76,9 @@ export class ActionViewComponent extends Component {
 
         this.explorerViewComponent.registerListeners();
 
-        this._eventEmitter.register('EOnActionViewChange', (name) => this.onActionViewChange(name));
-        this._eventEmitter.register('EOnActionViewOpen', () => this.openActionView());
-        this._eventEmitter.register('EOnActionViewClose', () => this.closeActionView());
+        EVENT_EMITTER.register('EOnActionViewChange', (name) => this.onActionViewChange(name));
+        EVENT_EMITTER.register('EOnActionViewOpen', () => this.openActionView());
+        EVENT_EMITTER.register('EOnActionViewClose', () => this.closeActionView());
     }
 
     private _createActionViewTop(): HTMLElement {
@@ -108,7 +105,7 @@ export class ActionViewComponent extends Component {
         const actionViewContent = document.createElement('div');
         actionViewContent.id = 'action-view-content';
         
-        this.explorerViewComponent = new ExplorerViewComponent(this, this._eventEmitter, this._noteBookManager);
+        this.explorerViewComponent = new ExplorerViewComponent(this, this._noteBookManager);
         this.explorerViewComponent.create(actionViewContent);
 
         // outlineViewComponent...

--- a/src/code/workbench/browser/component.ts
+++ b/src/code/workbench/browser/component.ts
@@ -13,7 +13,7 @@ export interface IComponent {
 export abstract class Component implements IComponent, IRegisterService {
     
     protected parent!: HTMLElement;
-    protected container: HTMLElement = document.createElement('div');
+    protected readonly container: HTMLElement = document.createElement('div');
     protected contentArea: HTMLElement | undefined;
     protected contentAreaMap: Map<string, Component> = new Map();
     

--- a/src/code/workbench/browser/editor/editor.ts
+++ b/src/code/workbench/browser/editor/editor.ts
@@ -1,4 +1,3 @@
-import { IEventEmitter } from "src/base/common/event";
 import { Component, ComponentType } from "src/code/workbench/browser/component";
 import { MarkdownComponent } from "src/code/workbench/browser/editor/markdown/markdown";
 import { TitleBarComponent } from "src/code/workbench/browser/editor/titleBar/titleBar";
@@ -6,17 +5,12 @@ import { IRegisterService } from "src/code/workbench/service/registerService";
 
 export class EditorComponent extends Component {
 
-    private _eventEmitter: IEventEmitter;
-    
     private titleBarComponent!: TitleBarComponent;
     private markdownComponent!: MarkdownComponent;
 
-    constructor(registerService: IRegisterService,
-                _eventEmitter: IEventEmitter
-    ) {
+    constructor(registerService: IRegisterService) {
         super(ComponentType.editor, registerService);
 
-        this._eventEmitter = _eventEmitter;
         this.registerService = registerService;
     }
 
@@ -39,7 +33,7 @@ export class EditorComponent extends Component {
     }
 
     private _createTitleBar(): void {
-        this.titleBarComponent = new TitleBarComponent(this, this._eventEmitter);
+        this.titleBarComponent = new TitleBarComponent(this);
         this.titleBarComponent.create(this.container);
     }
 
@@ -47,7 +41,7 @@ export class EditorComponent extends Component {
         const markdownView = document.createElement('div');
         markdownView.id = 'markdown-view';
 
-        this.markdownComponent = new MarkdownComponent(this, this._eventEmitter);
+        this.markdownComponent = new MarkdownComponent(this);
         this.markdownComponent.create(markdownView);
 
         this.container.appendChild(markdownView);

--- a/src/code/workbench/browser/editor/markdown/markdown.ts
+++ b/src/code/workbench/browser/editor/markdown/markdown.ts
@@ -22,7 +22,7 @@ import { ConfigModule } from 'src/base/config';
 import { FileNode } from 'src/base/node/fileTree';
 import { Component } from 'src/code/workbench/browser/component';
 import { IRegisterService } from 'src/code/workbench/service/registerService';
-import { IEventEmitter } from 'src/base/common/event';
+import { EVENT_EMITTER } from 'src/base/common/event';
 import { MarkdownRenderMode } from 'mdnote';
 import { getSvgPathByName } from 'src/base/common/string';
 
@@ -31,8 +31,6 @@ import { getSvgPathByName } from 'src/base/common/string';
  * handling a few other shortcuts as well.
  */
 export class MarkdownComponent extends Component {
-    
-    private _eventEmitter: IEventEmitter;
 
     private editor: Editor | null;
     private saveFileTimeout: NodeJS.Timeout | null;
@@ -40,12 +38,9 @@ export class MarkdownComponent extends Component {
 
     private mode: MarkdownRenderMode;
 
-    constructor(registerService: IRegisterService,
-                _eventEmitter: IEventEmitter
-    ) {
+    constructor(registerService: IRegisterService) {
         super('markdown', registerService);
 
-        this._eventEmitter = _eventEmitter;
         this.mode = ConfigModule.defaultMarkdownMode;
         
         this.editor = null;
@@ -88,8 +83,8 @@ export class MarkdownComponent extends Component {
             markdown.setAttribute('spellcheck', 'false');
         }
 
-        this._eventEmitter.register('EMarkdownDisplayFile', (nodeInfo: FileNode) => this.markdownDisplayFile(nodeInfo));
-        this._eventEmitter.register('EMarkdownModeSwitch', () => this.markdownModeSwitch());
+        EVENT_EMITTER.register('EMarkdownDisplayFile', (nodeInfo: FileNode) => this.markdownDisplayFile(nodeInfo));
+        EVENT_EMITTER.register('EMarkdownModeSwitch', () => this.markdownModeSwitch());
         // ipcRendererOn('Ctrl+S', () => {
         //     if (!this.explorerViewComponent.TabBar.emptyTab) {
         //         if (this.saveFileTimeout) {
@@ -182,8 +177,8 @@ export class MarkdownComponent extends Component {
             return;
         }
 
-        if (nodeInfo) {
-            this.editor.setMarkdown(nodeInfo.file.plainText, false);
+        if (nodeInfo && !nodeInfo.isFolder) {
+            this.editor.setMarkdown(nodeInfo.file!.plainText, false);
         } else {
             this.editor.setMarkdown('', false);
         }

--- a/src/code/workbench/browser/editor/titleBar/tabBar.ts
+++ b/src/code/workbench/browser/editor/titleBar/tabBar.ts
@@ -93,7 +93,7 @@ export class TabBarComponent extends Component {
         // loop to search if the tab is existed or not
         let i = 0;
         for (i = 0; i < this.openedTabCount; i++) {
-            if (nodeInfo.file.path == (this.openedTabInfo[i] as FileNode).file.path) {
+            if (nodeInfo.path == (this.openedTabInfo[i] as FileNode).path) {
                 // tab exists
                 return [true, i, this.contentArea!.childNodes[i] as HTMLElement];
             }
@@ -106,7 +106,7 @@ export class TabBarComponent extends Component {
         
         newTab.classList.add('tab');
         tabText.classList.add('tab-text');
-        tabText.innerHTML = nodeInfo.file.name;
+        tabText.innerHTML = nodeInfo.name;
         tabCloseIcon.classList.add('tab-close-icon');
         tabCloseIcon.classList.add('vertical-center');
 
@@ -172,8 +172,8 @@ export class TabBarComponent extends Component {
     public displayTab(nodeInfo: FileNode | null): void {
         // setMarkdown() will emit Editor.event.change callback
         // ipcRenderer.send('test', 'setMarkdown()')
-        if (nodeInfo) {
-            ((window as any).editor as Editor).setMarkdown(nodeInfo.file.plainText, false);
+        if (nodeInfo && !nodeInfo.isFolder) {
+            ((window as any).editor as Editor).setMarkdown(nodeInfo.file!.plainText, false);
         } else {
             ((window as any).editor as Editor).setMarkdown('', false);
         }
@@ -202,7 +202,7 @@ export class TabBarComponent extends Component {
                 flag: 'w'
             };
             // FIX: shouldn't be nodeInfo.plainText, 
-            fs.writeFile(nodeInfo.file.path, nodeInfo.file.plainText, writeOption, (err) => {
+            fs.writeFile(nodeInfo.path, nodeInfo.file!.plainText, writeOption, (err) => {
                 if (err) {
                     throw err;
                 }
@@ -212,7 +212,7 @@ export class TabBarComponent extends Component {
             // pop up a warning window
             // TODO: complete
         }
-        nodeInfo.file.plainText = '';
+        nodeInfo.file!.plainText = '';
         let index = this.openedTabInfo.indexOf(nodeInfo);
         this.openedTabInfo.splice(index, 1);
         

--- a/src/code/workbench/browser/editor/titleBar/titleBar.ts
+++ b/src/code/workbench/browser/editor/titleBar/titleBar.ts
@@ -11,18 +11,12 @@ import { IEventEmitter } from 'src/base/common/event';
  */
 export class TitleBarComponent extends Component {
     
-    private _eventEmitter: IEventEmitter;
-
     toolBarComponent!: ToolBarComponent;
     tabBarComponent!: TabBarComponent;
     windowBarComponent!: WindowBarComponent;
 
-    constructor(registerService: IRegisterService,
-                _eventEmitter: IEventEmitter
-    ) {
+    constructor(registerService: IRegisterService) {
         super('title-bar', registerService);
-
-        this._eventEmitter = _eventEmitter;
     }
 
     protected override _createContainer(): void {
@@ -49,7 +43,7 @@ export class TitleBarComponent extends Component {
     }
 
     private _createToolBar(): void {
-        this.toolBarComponent = new ToolBarComponent(this, this._eventEmitter);
+        this.toolBarComponent = new ToolBarComponent(this);
         this.toolBarComponent.create(this.container);
     }
 

--- a/src/code/workbench/browser/editor/titleBar/toolBar.ts
+++ b/src/code/workbench/browser/editor/titleBar/toolBar.ts
@@ -1,6 +1,5 @@
-import { IEventEmitter } from "src/base/common/event";
-import { MarkdownRenderMode } from "mdnote";
 import { Button } from "src/base/browser/basic/button";
+import { EVENT_EMITTER } from "src/base/common/event";
 import { getSvgPathByName } from "src/base/common/string";
 import { ConfigModule } from "src/base/config";
 import { domNodeByIdAddListener } from "src/base/ipc/register";
@@ -9,18 +8,13 @@ import { IRegisterService } from "src/code/workbench/service/registerService";
 
 export class ToolBarComponent extends Component {
 
-    private _eventEmitter: IEventEmitter;
-
     isToolBarExpand: boolean;
     isMarkdownToolExpand: boolean;
     isTabBarExpand: boolean;
 
-    constructor(registerService: IRegisterService,
-                _eventEmitter: IEventEmitter
+    constructor(registerService: IRegisterService
     ) {
         super('tool-bar', registerService);
-
-        this._eventEmitter = _eventEmitter;
         
         this.isToolBarExpand = ConfigModule.isToolBarExpand;
         this.isMarkdownToolExpand = ConfigModule.isMarkdownToolExpand;
@@ -60,7 +54,7 @@ export class ToolBarComponent extends Component {
         this.initToolBar();
 
         domNodeByIdAddListener('mode-switch', 'click', () => {
-            this._eventEmitter.emit('EMarkdownModeSwitch');
+            EVENT_EMITTER.emit('EMarkdownModeSwitch');
         });
 
         domNodeByIdAddListener('md-tool', 'click', () => {

--- a/src/code/workbench/workbench.ts
+++ b/src/code/workbench/workbench.ts
@@ -3,7 +3,6 @@ import { IRegisterService } from "src/code/workbench/service/registerService";
 import { ActionViewComponent } from "src/code/workbench/browser/actionView/actionView";
 import { ActionBarComponent } from "src/code/workbench/browser/actionBar/actionBar";
 import { EditorComponent } from "src/code/workbench/browser/editor/editor";
-import { EventEmitter, IEventEmitter } from "src/base/common/event";
 import { INoteBookManager, NoteBookManager } from "src/code/common/notebookManger";
 
 /**
@@ -17,7 +16,6 @@ class Workbench implements IRegisterService {
 
     private componentMap = new Map<string, Component>();
 
-    private _eventEmitter: IEventEmitter;
     private _noteBookManager: INoteBookManager;
 
     actionBarComponent!: ActionBarComponent;
@@ -25,7 +23,6 @@ class Workbench implements IRegisterService {
     editorComponent!: EditorComponent;
     
     constructor() {
-        this._eventEmitter = new EventEmitter();
         this._noteBookManager = new NoteBookManager();
 
         this.initComponents();
@@ -37,9 +34,9 @@ class Workbench implements IRegisterService {
      * rendering.
      */
     private initComponents(): void {
-        this.actionBarComponent = new ActionBarComponent(this, this._eventEmitter);
-        this.actionViewComponent = new ActionViewComponent(this, this._eventEmitter, this._noteBookManager);
-        this.editorComponent = new EditorComponent(this, this._eventEmitter);
+        this.actionBarComponent = new ActionBarComponent(this);
+        this.actionViewComponent = new ActionViewComponent(this, this._noteBookManager);
+        this.editorComponent = new EditorComponent(this);
     }
 
     /**

--- a/src/styles/actionView/explorer/fileTree.css
+++ b/src/styles/actionView/explorer/fileTree.css
@@ -4,7 +4,7 @@
     height:100%;
 }
 
-#tree {
+#fileTree-container {
     position: absolute;
     width: 100%;
     height: 100%;
@@ -20,14 +20,14 @@
     transition: color 0.2s ease;
 }
 
-#tree:hover {
+#fileTree-container:hover {
     color: rgba(0, 0, 0, 0.8); /* shoud matches text-shadow */
 }
 
-#tree ul {
+#fileTree-container ul {
     padding-left: 6px;
 }
-#tree li {
+#fileTree-container li {
     padding-left: 6px;
 }
 


### PR DESCRIPTION
## Summary of changes 
* set a global EVENT_EMITTER 584b134b960574d31d24465b7996ab666df2878d
* more intelligence detection in nameIncludeCheckWithRule() eda2ac03a5d1bcc9fd00db9abe36d888e0e4578a
* explorer.ts && fileTree.ts refactor 2c6ef194dfff291606caa806ae18c4fedabc8c87
  * explorer no longer has methods relate to file tree manipulation (all moved into fileTree.ts)
  * MarkdownFile class no longer has attribute path, name, baseName (all moved back into FileNode class)
  * each file node related HTML element is created during the recursion in reading directory
    * P.S. 在以前, 先递归一边目录去读取并建立fileTree, 然后再递归一边去渲染HTML element, 总共递归了两边tree. 现在data和view在第一遍即可完成, 
### Future work
* fileTree.ts
  * 在未来会有一个按钮去即时切换explorer的noteMode和fileTreeMode, 因此上述最终还是会被分成viewModel和view.

### Checklist
- [ ] BUG: folder node不能被正常点击. 涉及函数: FileNode -> public static folderOnClick()
